### PR TITLE
fix(laravel-set): add condition

### DIFF
--- a/src/Service/ScheduleHandler.php
+++ b/src/Service/ScheduleHandler.php
@@ -41,6 +41,10 @@ final readonly class ScheduleHandler implements ScheduleInterface
         foreach ($filenames as $filename) {
             $scheduleClass = require_once $filename;
 
+            if ($scheduleClass === true) {
+                continue;
+            }
+
             if (! $scheduleClass instanceof ScheduleInterface) {
                 throw new InvalidArgumentException(
                     \sprintf(


### PR DESCRIPTION
Ajout d'une condition qui permet d’ignorer les fichiers déjà inclus précédemment, car require_once renvoie true lorsqu’un fichier a déjà été chargé.