### PR TITLE
feat(images): use image compression levels instead of quality

### DIFF
--- a/src/Media/Dto/Config/ImageCompressionLevelDto.php
+++ b/src/Media/Dto/Config/ImageCompressionLevelDto.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylarele\LaravelSet\Media\Dto\Config;
+
+final readonly class ImageCompressionLevelDto
+{
+    /**
+     * @param int<0, 100> $sizeFrom Percentage of the total image size at which this level starts to apply
+     * @param int<1, 100> $quality Quality percentage applied at this level
+     */
+    public function __construct(
+        public int $sizeFrom,
+        public int $quality,
+    ) {
+    }
+}

--- a/src/Media/Dto/Config/ImageConfigDto.php
+++ b/src/Media/Dto/Config/ImageConfigDto.php
@@ -13,7 +13,7 @@ final readonly class ImageConfigDto
     public function __construct(
         public ?int $resizeHeight = null,
         public ?int $resizeWidth = null,
-        public int $quality = 100,
+        public ?BackedEnum $imageCompressionLevel = null,
         public ?Position $position = null,
         public Format $format = Format::Webp,
     ) {
@@ -29,7 +29,10 @@ final readonly class ImageConfigDto
         return new self(
             resizeHeight: $integerData['resizeHeight'] ?? null,
             resizeWidth: $integerData['resizeWidth'] ?? null,
-            quality: $integerData['quality'] ?? 100,
+            imageCompressionLevel: array_key_exists('imageCompressionLevel', $properties)
+                && $properties['imageCompressionLevel'] instanceof BackedEnum
+                    ? $properties['imageCompressionLevel']
+                    : null,
             position: isset($properties['position']) &&  $properties['position'] instanceof Position
                 ? $properties['position']
                 : null,


### PR DESCRIPTION
# Description

Use a `BackedEnum` for image compression level instead of single `quality` property.